### PR TITLE
chore: Enable pre-commit and pre-push checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: install dependencies
           command: |
             sudo pip install pipenv
-            pipenv install --dev
+            pipenv install --dev -e .
 
       - save_cache:
           key: deps-{{ checksum "Pipfile.lock" }}-{{ .Environment.PYVERSION }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
       - run:
           name: run tests
           command: |
+            pipenv run isort --check --diff .
+            pipenv run black --check .
+            pipenv run flake8 data_lineage test
             pipenv run pytest --junitxml=junit/test-results.xml --cov-report=xml --cov-report=html test/
 
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,26 +22,3 @@ repos:
         entry: pipenv run flake8
         types: [python]
         exclude: setup.py
-
-      - id: mypy
-        name: mypy
-        stages: [commit]
-        language: system
-        entry: pipenv run mypy
-        types: [python]
-        pass_filenames: false
-
-      - id: pytest
-        name: pytest
-        stages: [commit]
-        language: system
-        entry: pipenv run pytest
-        types: [python]
-
-      - id: pytest-cov
-        name: pytest
-        stages: [push]
-        language: system
-        entry: pipenv run pytest --cov --cov-fail-under=100
-        types: [python]
-        pass_filenames: false

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"
 
 [packages]
 pglast = "*"
@@ -16,7 +16,6 @@ plotly = "*"
 black = "==19.3b0"
 flake8 = "*"
 isort = "*"
-mypy = "*"
 pre-commit = "*"
 pytest = "*"
 pytest-cov = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ networkx = "*"
 plotly = "*"
 
 [dev-packages]
-black = "==19.3b0"
+black = "==19.10b0"
 flake8 = "*"
 isort = "*"
 pre-commit = "*"
@@ -21,3 +21,8 @@ pytest = "*"
 pytest-cov = "*"
 twine = "*"
 wheel = "*"
+pipenv-setup = "*"
+
+[dev-packages.e1839a8]
+path = "."
+editable = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4dcfe956931e1adf93b8c59facf59a7a8655951e71347a16b430ed1d80944063"
+            "sha256": "f52fa5d0eead5ed6a986f6d8b1b901e1b2fd9c085f3d37c91c418429a2bab97e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -101,11 +101,12 @@
         },
         "black": {
             "hashes": [
-                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
-                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
             ],
             "index": "pypi",
-            "version": "==19.3b0"
+            "markers": "python_version >= '3.6'",
+            "version": "==19.10b0"
         },
         "bleach": {
             "hashes": [
@@ -113,6 +114,19 @@
                 "sha256:9f8ccbeb6183c6e6cddea37592dfb0167485c1e3b13b3363bc325aa8bda3adbd"
             ],
             "version": "==3.2.1"
+        },
+        "cached-property": {
+            "hashes": [
+                "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130",
+                "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"
+            ],
+            "version": "==1.5.2"
+        },
+        "cerberus": {
+            "hashes": [
+                "sha256:302e6694f206dd85cb63f13fd5025b31ab6d38c99c50c6d769f8fa0b0f299589"
+            ],
+            "version": "==1.3.2"
         },
         "certifi": {
             "hashes": [
@@ -256,6 +270,13 @@
             ],
             "version": "==3.2.1"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
+                "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
+            ],
+            "version": "==4.4.2"
+        },
         "distlib": {
             "hashes": [
                 "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb",
@@ -269,6 +290,10 @@
                 "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
             "version": "==0.16"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
         },
         "filelock": {
             "hashes": [
@@ -298,6 +323,14 @@
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
             "version": "==2.10"
+        },
+        "inflection": {
+            "hashes": [
+                "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417",
+                "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"
+            ],
+            "index": "pypi",
+            "version": "==0.5.1"
         },
         "iniconfig": {
             "hashes": [
@@ -335,12 +368,27 @@
             ],
             "version": "==0.6.1"
         },
+        "networkx": {
+            "hashes": [
+                "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602",
+                "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"
+            ],
+            "index": "pypi",
+            "version": "==2.5"
+        },
         "nodeenv": {
             "hashes": [
                 "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9",
                 "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"
             ],
             "version": "==1.5.0"
+        },
+        "orderedmultidict": {
+            "hashes": [
+                "sha256:04070bbb5e87291cc9bfa51df413677faf2141c73c61d2a5f7b26bea3cd882ad",
+                "sha256:43c839a17ee3cdd62234c47deca1a8508a3f2ca1d0678a3bf791c87cf84adbf3"
+            ],
+            "version": "==1.0.1"
         },
         "packaging": {
             "hashes": [
@@ -349,12 +397,85 @@
             ],
             "version": "==20.4"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
+                "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
+            ],
+            "version": "==0.8.0"
+        },
+        "pep517": {
+            "hashes": [
+                "sha256:3985b91ebf576883efe5fa501f42a16de2607684f3797ddba7202b71b7d0da51",
+                "sha256:aeb78601f2d1aa461960b43add204cc7955667687fbcf9cdb5170f00556f117f"
+            ],
+            "version": "==0.9.1"
+        },
+        "pglast": {
+            "hashes": [
+                "sha256:14a7e3eb80ad4173f65d4ef2f12f13b1863a514c35b6b2a070cfe68ba9470b0d",
+                "sha256:216f4787a63cb73ad5d91d2aa5c4d4de2ad05bd90351410f1c47e97117d34fca",
+                "sha256:2380edf98a3b35b629399f125167bd88e4b63b5aadfd0bae9ee5df3b81661285",
+                "sha256:30052f254823a60ea2c660d94cfc233b281d877ed911e1994ca84b87bb5adebd",
+                "sha256:5024721f49858efe626fda7ed781509d6d063cb20aace4cc3c3a6708a05035f9",
+                "sha256:52582efd0eb43685192bc3a2c67857360d57284948560c00fee91e43b6dd4fd3",
+                "sha256:5537a1fe3717991d6940897e91651a162b59430d1a29342b1a88832e5b6bb101",
+                "sha256:5eb45b42b7a3fdff2be983cf4d4f3418b88a1af4b4d50999132898b45c2c906d",
+                "sha256:72652b9edc7bdbfc9c3192235fb2fa1b2fb73a681613368fcaec747d7f5e479f",
+                "sha256:8393dd45e0c3f1d59490398edd0ea626637ae53e90fd5080f98c74ab41226836",
+                "sha256:83c1e07c8f74de7c96372e739e64962b2cdcdb0ef8896cfe86394df82d98577a",
+                "sha256:83e11cf7590f1e1c60b43a40dbde2b18a7fcc33a01957a37679ddb70f10878be",
+                "sha256:9b62c010541752ccdd2ce21dd3d046b1f2f24246ea08965d6c5a8c8f86a23015",
+                "sha256:ae550896ea45287a232a012cb781161988347e89590905d704ac7390466a2826",
+                "sha256:b8c5dd58f9a201c85325dd340764d407789a2e7a73648c90c7dc71fc47ee1d09",
+                "sha256:ddb8a8c349455c891170abc9c0a967c490d85506f7744d198d4cb909aecfa4b2",
+                "sha256:f853fe7aa5a0d26b2637c121dd0190e378dafe8925581c74aa05045c583d51a9"
+            ],
+            "index": "pypi",
+            "version": "==1.14"
+        },
+        "pip-shims": {
+            "hashes": [
+                "sha256:05b00ade9d1e686a98bb656dd9b0608a933897283dc21913fad6ea5409ff7e91",
+                "sha256:16ca9f87485667b16b978b68a1aae4f9cc082c0fa018aed28567f9f34a590569"
+            ],
+            "version": "==0.5.3"
+        },
+        "pipenv-setup": {
+            "hashes": [
+                "sha256:8a439aff7b16e18d7e07702c9186fc5fe86156679eace90e10c2578a43bd7af1",
+                "sha256:e1bfd55c1152024e762f1c17f6189fcb073166509e7c0228870f7ea160355648"
+            ],
+            "index": "pypi",
+            "version": "==3.1.1"
+        },
+        "pipfile": {
+            "hashes": [
+                "sha256:f7d9f15de8b660986557eb3cc5391aa1a16207ac41bc378d03f414762d36c984"
+            ],
+            "version": "==0.0.2"
+        },
         "pkginfo": {
             "hashes": [
                 "sha256:a6a4ac943b496745cec21f14f021bbd869d5e9b4f6ec06918cffea5a2f4b9193",
                 "sha256:ce14d7296c673dc4c61c759a0b6c14bae34e34eb819c0017bb6ca5b7292c56e9"
             ],
             "version": "==1.6.1"
+        },
+        "plette": {
+            "hashes": [
+                "sha256:46402c03e36d6eadddad2a5125990e322dd74f98160c8f2dcd832b2291858a26",
+                "sha256:d6c9b96981b347bddd333910b753b6091a2c1eb2ef85bb373b4a67c9d91dca16"
+            ],
+            "version": "==0.2.3"
+        },
+        "plotly": {
+            "hashes": [
+                "sha256:9ec2c9f4cceac7c595ebb77c98cbeb6566a97bef777508584d9bb7d9bcb8854c",
+                "sha256:c50babbb4f8ad12e2a4f004df5d80c1dbf10c38e9325b5ffb1146b383687ef52"
+            ],
+            "index": "pypi",
+            "version": "==4.12.0"
         },
         "pluggy": {
             "hashes": [
@@ -429,6 +550,13 @@
             "index": "pypi",
             "version": "==2.10.1"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
         "pyyaml": {
             "hashes": [
                 "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
@@ -452,6 +580,54 @@
             ],
             "version": "==28.0"
         },
+        "regex": {
+            "hashes": [
+                "sha256:03855ee22980c3e4863dc84c42d6d2901133362db5daf4c36b710dd895d78f0a",
+                "sha256:06b52815d4ad38d6524666e0d50fe9173533c9cc145a5779b89733284e6f688f",
+                "sha256:11116d424734fe356d8777f89d625f0df783251ada95d6261b4c36ad27a394bb",
+                "sha256:119e0355dbdd4cf593b17f2fc5dbd4aec2b8899d0057e4957ba92f941f704bf5",
+                "sha256:127a9e0c0d91af572fbb9e56d00a504dbd4c65e574ddda3d45b55722462210de",
+                "sha256:1ec66700a10e3c75f1f92cbde36cca0d3aaee4c73dfa26699495a3a30b09093c",
+                "sha256:227a8d2e5282c2b8346e7f68aa759e0331a0b4a890b55a5cfbb28bd0261b84c0",
+                "sha256:2564def9ce0710d510b1fc7e5178ce2d20f75571f788b5197b3c8134c366f50c",
+                "sha256:297116e79074ec2a2f885d22db00ce6e88b15f75162c5e8b38f66ea734e73c64",
+                "sha256:2dc522e25e57e88b4980d2bdd334825dbf6fa55f28a922fc3bfa60cc09e5ef53",
+                "sha256:3a5f08039eee9ea195a89e180c5762bfb55258bfb9abb61a20d3abee3b37fd12",
+                "sha256:3dfca201fa6b326239e1bccb00b915e058707028809b8ecc0cf6819ad233a740",
+                "sha256:49461446b783945597c4076aea3f49aee4b4ce922bd241e4fcf62a3e7c61794c",
+                "sha256:4afa350f162551cf402bfa3cd8302165c8e03e689c897d185f16a167328cc6dd",
+                "sha256:4b5a9bcb56cc146c3932c648603b24514447eafa6ce9295234767bf92f69b504",
+                "sha256:52e83a5f28acd621ba8e71c2b816f6541af7144b69cc5859d17da76c436a5427",
+                "sha256:625116aca6c4b57c56ea3d70369cacc4d62fead4930f8329d242e4fe7a58ce4b",
+                "sha256:654c1635f2313d0843028487db2191530bca45af61ca85d0b16555c399625b0e",
+                "sha256:8092a5a06ad9a7a247f2a76ace121183dc4e1a84c259cf9c2ce3bbb69fac3582",
+                "sha256:832339223b9ce56b7b15168e691ae654d345ac1635eeb367ade9ecfe0e66bee0",
+                "sha256:8ca9dca965bd86ea3631b975d63b0693566d3cc347e55786d5514988b6f5b84c",
+                "sha256:96f99219dddb33e235a37283306834700b63170d7bb2a1ee17e41c6d589c8eb9",
+                "sha256:9b6305295b6591e45f069d3553c54d50cc47629eb5c218aac99e0f7fafbf90a1",
+                "sha256:a62162be05edf64f819925ea88d09d18b09bebf20971b363ce0c24e8b4aa14c0",
+                "sha256:aacc8623ffe7999a97935eeabbd24b1ae701d08ea8f874a6ff050e93c3e658cf",
+                "sha256:b45bab9f224de276b7bc916f6306b86283f6aa8afe7ed4133423efb42015a898",
+                "sha256:b88fa3b8a3469f22b4f13d045d9bd3eda797aa4e406fde0a2644bc92bbdd4bdd",
+                "sha256:b8a686a6c98872007aa41fdbb2e86dc03b287d951ff4a7f1da77fb7f14113e4d",
+                "sha256:bd904c0dec29bbd0769887a816657491721d5f545c29e30fd9d7a1a275dc80ab",
+                "sha256:bf4f896c42c63d1f22039ad57de2644c72587756c0cfb3cc3b7530cfe228277f",
+                "sha256:c13d311a4c4a8d671f5860317eb5f09591fbe8259676b86a85769423b544451e",
+                "sha256:c2c6c56ee97485a127555c9595c069201b5161de9d05495fbe2132b5ac104786",
+                "sha256:c32c91a0f1ac779cbd73e62430de3d3502bbc45ffe5bb6c376015acfa848144b",
+                "sha256:c3466a84fce42c2016113101018a9981804097bacbab029c2d5b4fcb224b89de",
+                "sha256:c454ad88e56e80e44f824ef8366bb7e4c3def12999151fd5c0ea76a18fe9aa3e",
+                "sha256:c8a2b7ccff330ae4c460aff36626f911f918555660cc28163417cb84ffb25789",
+                "sha256:cb905f3d2e290a8b8f1579d3984f2cfa7c3a29cc7cba608540ceeed18513f520",
+                "sha256:cfcf28ed4ce9ced47b9b9670a4f0d3d3c0e4d4779ad4dadb1ad468b097f808aa",
+                "sha256:dd3e6547ecf842a29cf25123fbf8d2461c53c8d37aa20d87ecee130c89b7079b",
+                "sha256:de7fd57765398d141949946c84f3590a68cf5887dac3fc52388df0639b01eda4",
+                "sha256:ea37320877d56a7f0a1e6a625d892cf963aa7f570013499f5b8d5ab8402b5625",
+                "sha256:f1fce1e4929157b2afeb4bb7069204d4370bab9f4fc03ca1fbec8bd601f8c87d",
+                "sha256:f43109822df2d3faac7aad79613f5f02e4eab0fc8ad7932d2e70e2a83bd49c26"
+            ],
+            "version": "==2020.10.28"
+        },
         "requests": {
             "hashes": [
                 "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
@@ -465,6 +641,19 @@
                 "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
             ],
             "version": "==0.9.1"
+        },
+        "requirementslib": {
+            "hashes": [
+                "sha256:029dd232c5e384ce9b3d7c14876558f9b6176e564ac3628de149243667ccdaa0",
+                "sha256:fe4486d936489239ae2f10b114fcc5e81e13e41fe742b924c2970be32c6efeb2"
+            ],
+            "version": "==1.5.15"
+        },
+        "retrying": {
+            "hashes": [
+                "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
+            ],
+            "version": "==1.3.3"
         },
         "rfc3986": {
             "hashes": [
@@ -495,6 +684,13 @@
             ],
             "version": "==0.10.2"
         },
+        "tomlkit": {
+            "hashes": [
+                "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831",
+                "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"
+            ],
+            "version": "==0.7.0"
+        },
         "tqdm": {
             "hashes": [
                 "sha256:9ad44aaf0fc3697c06f6e05c7cf025dd66bc7bcb7613c66d85f4464c47ac8fad",
@@ -510,6 +706,41 @@
             "index": "pypi",
             "version": "==3.2.0"
         },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072",
+                "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298",
+                "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
@@ -523,6 +754,13 @@
                 "sha256:b8d6110f493af256a40d65e29846c69340a947669eec8ce784fcf3dd3af28380"
             ],
             "version": "==20.1.0"
+        },
+        "vistir": {
+            "hashes": [
+                "sha256:a37079cdbd85d31a41cdd18457fe521e15ec08b255811e81aa061fd5f48a20fb",
+                "sha256:eff1d19ef50c703a329ed294e5ec0b0fbb35b96c1b3ee6dcdb266dddbe1e935a"
+            ],
+            "version": "==0.5.2"
         },
         "webencodings": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cc07e590205369392796e70490346a01b234905934e18c46d34426a49d0fd2bf"
+            "sha256": "4dcfe956931e1adf93b8c59facf59a7a8655951e71347a16b430ed1d80944063"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -25,49 +25,50 @@
         },
         "inflection": {
             "hashes": [
-                "sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca"
+                "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417",
+                "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"
             ],
             "index": "pypi",
-            "version": "==0.3.1"
+            "version": "==0.5.1"
         },
         "networkx": {
             "hashes": [
-                "sha256:cdfbf698749a5014bf2ed9db4a07a5295df1d3a53bf80bf3cbd61edf9df05fa1",
-                "sha256:f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64"
+                "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602",
+                "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"
             ],
             "index": "pypi",
-            "version": "==2.4"
+            "version": "==2.5"
         },
         "pglast": {
             "hashes": [
-                "sha256:0eeb140abe24148f5ec771cd6acc7ab5efc84541c18c02144a5a0015d11e915b",
-                "sha256:100fe6319ac4fb37d53e24f19767ee9556eb59b386c027b84b61306897c896b3",
-                "sha256:296f2994c136ceb8f52cf98de73ada2da40c06eddd7598207194aa75f8c0b6a7",
-                "sha256:327dab64fd177eef0eccc10959c352ba22c8ef70f1eaca9f712d58573b326549",
-                "sha256:3cff2142c06ddaf7b0ff04e6a35a0d4c2989431f052b0fea2c3bc79469b81837",
-                "sha256:4495b5ad82ac18737df7729e8f360291ad5d5b28478d01dc073af5ea4bf0397a",
-                "sha256:5aba6a94489526b66c2c690d686e88b73bfd5f601b4d98e8c8c4da378777be59",
-                "sha256:5d183d2259969f5ad9c81955c1d628f134ad9c3dafc97883eec6ada30eff17fc",
-                "sha256:70b4e50d355052181f690a12ba1700268b428cc984da75d6598fbf0737571a94",
-                "sha256:88f74bea8986803c832f82f00da927a8bafad43c9b9f006223c21b34d0678f4b",
-                "sha256:89dd5f5d4b5b2a1a4cefa483ab234aa3acbbdf0cbd2931a8fae1f7258627a132",
-                "sha256:a26ba77127b363446955e8a5317b3194defb1c1bb9d2ed5e7d4830fd4f066d97",
-                "sha256:b59009d3acf412c0cda7a9c8c5d01b256a3d6638dffa52e8c8591ca4b534ea49",
-                "sha256:bf10846005409cd037c804e278205dad069b20dc2aafeb273c2275cb137671a9",
-                "sha256:c3578e93bfa81118e095319d454fb5d0a4e826c58fef5675ed9e89fa1a579f65",
-                "sha256:fcfb5b6844c9350fcafbe30c0251e401b72b8b12cb8a1d39984f3c4083402b31",
-                "sha256:fee345b584317e4ef301f3242713e0edaeb8530c02c5874d3beb2882ea22fdd9"
+                "sha256:14a7e3eb80ad4173f65d4ef2f12f13b1863a514c35b6b2a070cfe68ba9470b0d",
+                "sha256:216f4787a63cb73ad5d91d2aa5c4d4de2ad05bd90351410f1c47e97117d34fca",
+                "sha256:2380edf98a3b35b629399f125167bd88e4b63b5aadfd0bae9ee5df3b81661285",
+                "sha256:30052f254823a60ea2c660d94cfc233b281d877ed911e1994ca84b87bb5adebd",
+                "sha256:5024721f49858efe626fda7ed781509d6d063cb20aace4cc3c3a6708a05035f9",
+                "sha256:52582efd0eb43685192bc3a2c67857360d57284948560c00fee91e43b6dd4fd3",
+                "sha256:5537a1fe3717991d6940897e91651a162b59430d1a29342b1a88832e5b6bb101",
+                "sha256:5eb45b42b7a3fdff2be983cf4d4f3418b88a1af4b4d50999132898b45c2c906d",
+                "sha256:72652b9edc7bdbfc9c3192235fb2fa1b2fb73a681613368fcaec747d7f5e479f",
+                "sha256:8393dd45e0c3f1d59490398edd0ea626637ae53e90fd5080f98c74ab41226836",
+                "sha256:83c1e07c8f74de7c96372e739e64962b2cdcdb0ef8896cfe86394df82d98577a",
+                "sha256:83e11cf7590f1e1c60b43a40dbde2b18a7fcc33a01957a37679ddb70f10878be",
+                "sha256:9b62c010541752ccdd2ce21dd3d046b1f2f24246ea08965d6c5a8c8f86a23015",
+                "sha256:ae550896ea45287a232a012cb781161988347e89590905d704ac7390466a2826",
+                "sha256:b8c5dd58f9a201c85325dd340764d407789a2e7a73648c90c7dc71fc47ee1d09",
+                "sha256:ddb8a8c349455c891170abc9c0a967c490d85506f7744d198d4cb909aecfa4b2",
+                "sha256:f853fe7aa5a0d26b2637c121dd0190e378dafe8925581c74aa05045c583d51a9"
             ],
             "index": "pypi",
-            "version": "==1.10"
+            "version": "==1.14"
         },
         "plotly": {
             "hashes": [
-                "sha256:b6b1e13e7f04dc9a9f714ab8ecc63d00a4207a736c9835912c96b6884002be1e",
-                "sha256:e6eab2b6010921f5fb998860125b90748e581de66ebc6107b686829417d98fc4"
+                "sha256:9ec2c9f4cceac7c595ebb77c98cbeb6566a97bef777508584d9bb7d9bcb8854c",
+                "sha256:c50babbb4f8ad12e2a4f004df5d80c1dbf10c38e9325b5ffb1146b383687ef52"
             ],
             "index": "pypi",
-            "version": "==4.5.4"
+            "version": "==4.12.0"
         },
         "retrying": {
             "hashes": [
@@ -93,10 +94,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
-                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "version": "==20.2.0"
+            "version": "==20.3.0"
         },
         "black": {
             "hashes": [
@@ -182,6 +183,13 @@
             ],
             "version": "==7.1.2"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "version": "==0.4.4"
+        },
         "coverage": {
             "hashes": [
                 "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516",
@@ -223,31 +231,30 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:22f8251f68953553af4f9c11ec5f191198bc96cff9f0ac5dd5ff94daede0ee6d",
-                "sha256:284e275e3c099a80831f9898fb5c9559120d27675c3521278faba54e584a7832",
-                "sha256:3e17d02941c0f169c5b877597ca8be895fca0e5e3eb882526a74aa4804380a98",
-                "sha256:52a47e60953679eea0b4d490ca3c241fb1b166a7b161847ef4667dfd49e7699d",
-                "sha256:57b8c1ed13b8aa386cabbfde3be175d7b155682470b0e259fecfe53850967f8a",
-                "sha256:6a8f64ed096d13f92d1f601a92d9fd1f1025dc73a2ca1ced46dcf5e0d4930943",
-                "sha256:6e8a3c7c45101a7eeee93102500e1b08f2307c717ff553fcb3c1127efc9b6917",
-                "sha256:7ef41304bf978f33cfb6f43ca13bb0faac0c99cda33693aa20ad4f5e34e8cb8f",
-                "sha256:87c2fffd61e934bc0e2c927c3764c20b22d7f5f7f812ee1a477de4c89b044ca6",
-                "sha256:88069392cd9a1e68d2cfd5c3a2b0d72a44ef3b24b8977a4f7956e9e3c4c9477a",
-                "sha256:8a0866891326d3badb17c5fd3e02c926b635e8923fa271b4813cd4d972a57ff3",
-                "sha256:8f0fd8b0751d75c4483c534b209e39e918f0d14232c0d8a2a76e687f64ced831",
-                "sha256:9a07e6d255053674506091d63ab4270a119e9fc83462c7ab1dbcb495b76307af",
-                "sha256:9a8580c9afcdcddabbd064c0a74f337af74ff4529cdf3a12fa2e9782d677a2e5",
-                "sha256:bd80bc156d3729b38cb227a5a76532aef693b7ac9e395eea8063ee50ceed46a5",
-                "sha256:d1cbc3426e6150583b22b517ef3720036d7e3152d428c864ff0f3fcad2b97591",
-                "sha256:e15ac84dcdb89f92424cbaca4b0b34e211e7ce3ee7b0ec0e4f3c55cee65fae5a",
-                "sha256:e4789b84f8dedf190148441f7c5bfe7244782d9cbb194a36e17b91e7d3e1cca9",
-                "sha256:f01c9116bfb3ad2831e125a73dcd957d173d6ddca7701528eff1e7d97972872c",
-                "sha256:f0e3986f6cce007216b23c490f093f35ce2068f3c244051e559f647f6731b7ae",
-                "sha256:f2aa3f8ba9e2e3fd49bd3de743b976ab192fbf0eb0348cebde5d2a9de0090a9f",
-                "sha256:fb70a4cedd69dc52396ee114416a3656e011fb0311fca55eb55c7be6ed9c8aef"
+                "sha256:07ca431b788249af92764e3be9a488aa1d39a0bc3be313d826bbec690417e538",
+                "sha256:13b88a0bd044b4eae1ef40e265d006e34dbcde0c2f1e15eb9896501b2d8f6c6f",
+                "sha256:32434673d8505b42c0de4de86da8c1620651abd24afe91ae0335597683ed1b77",
+                "sha256:3cd75a683b15576cfc822c7c5742b3276e50b21a06672dc3a800a2d5da4ecd1b",
+                "sha256:4e7268a0ca14536fecfdf2b00297d4e407da904718658c1ff1961c713f90fd33",
+                "sha256:545a8550782dda68f8cdc75a6e3bf252017aa8f75f19f5a9ca940772fc0cb56e",
+                "sha256:55d0b896631412b6f0c7de56e12eb3e261ac347fbaa5d5e705291a9016e5f8cb",
+                "sha256:5849d59358547bf789ee7e0d7a9036b2d29e9a4ddf1ce5e06bb45634f995c53e",
+                "sha256:6dc59630ecce8c1f558277ceb212c751d6730bd12c80ea96b4ac65637c4f55e7",
+                "sha256:7117319b44ed1842c617d0a452383a5a052ec6aa726dfbaffa8b94c910444297",
+                "sha256:75e8e6684cf0034f6bf2a97095cb95f81537b12b36a8fedf06e73050bb171c2d",
+                "sha256:7b8d9d8d3a9bd240f453342981f765346c87ade811519f98664519696f8e6ab7",
+                "sha256:a035a10686532b0587d58a606004aa20ad895c60c4d029afa245802347fab57b",
+                "sha256:a4e27ed0b2504195f855b52052eadcc9795c59909c9d84314c5408687f933fc7",
+                "sha256:a733671100cd26d816eed39507e585c156e4498293a907029969234e5e634bc4",
+                "sha256:a75f306a16d9f9afebfbedc41c8c2351d8e61e818ba6b4c40815e2b5740bb6b8",
+                "sha256:bd717aa029217b8ef94a7d21632a3bb5a4e7218a4513d2521c2a2fd63011e98b",
+                "sha256:d25cecbac20713a7c3bc544372d42d8eafa89799f492a43b79e1dfd650484851",
+                "sha256:d26a2557d8f9122f9bf445fc7034242f4375bd4e95ecda007667540270965b13",
+                "sha256:d3545829ab42a66b84a9aaabf216a4dce7f16dbc76eb69be5c302ed6b8f4a29b",
+                "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3",
+                "sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df"
             ],
-            "index": "pypi",
-            "version": "==3.2"
+            "version": "==3.2.1"
         },
         "distlib": {
             "hashes": [
@@ -263,13 +270,6 @@
             ],
             "version": "==0.16"
         },
-        "entrypoints": {
-            "hashes": [
-                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
-                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
-            ],
-            "version": "==0.3"
-        },
         "filelock": {
             "hashes": [
                 "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
@@ -279,18 +279,18 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
-                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
             ],
             "index": "pypi",
-            "version": "==3.7.9"
+            "version": "==3.8.4"
         },
         "identify": {
             "hashes": [
-                "sha256:3139bf72d81dfd785b0a464e2776bd59bdc725b4cc10e6cf46b56a0db931c82e",
-                "sha256:969d844b7a85d32a5f9ac4e163df6e846d73c87c8b75847494ee8f4bd2186421"
+                "sha256:5dd84ac64a9a115b8e0b27d1756b244b882ad264c3c423f42af8235a6e71ca12",
+                "sha256:c9504ba6a043ee2db0a9d69e43246bc138034895f6338d5aed1b41e4a73b1513"
             ],
-            "version": "==1.5.6"
+            "version": "==1.5.9"
         },
         "idna": {
             "hashes": [
@@ -299,28 +299,26 @@
             ],
             "version": "==2.10"
         },
-        "importlib-metadata": {
+        "iniconfig": {
             "hashes": [
-                "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da",
-                "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
             ],
-            "markers": "python_version < '3.8'",
-            "version": "==2.0.0"
+            "version": "==1.1.1"
         },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7",
+                "sha256:dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
             ],
             "index": "pypi",
-            "version": "==4.3.21"
+            "version": "==5.6.4"
         },
         "jeepney": {
             "hashes": [
                 "sha256:3479b861cc2b6407de5188695fa1a8d57e5072d7059322469b62628869b8e36e",
                 "sha256:d6c6b49683446d2407d2fe3acb7a368a77ff063f9182fe427da15d622adc24cf"
             ],
-            "markers": "sys_platform == 'linux'",
             "version": "==0.4.3"
         },
         "keyring": {
@@ -336,40 +334,6 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
-        },
-        "more-itertools": {
-            "hashes": [
-                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
-                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
-            ],
-            "version": "==8.5.0"
-        },
-        "mypy": {
-            "hashes": [
-                "sha256:15b948e1302682e3682f11f50208b726a246ab4e6c1b39f9264a8796bb416aa2",
-                "sha256:219a3116ecd015f8dca7b5d2c366c973509dfb9a8fc97ef044a36e3da66144a1",
-                "sha256:3b1fc683fb204c6b4403a1ef23f0b1fac8e4477091585e0c8c54cbdf7d7bb164",
-                "sha256:3beff56b453b6ef94ecb2996bea101a08f1f8a9771d3cbf4988a61e4d9973761",
-                "sha256:7687f6455ec3ed7649d1ae574136835a4272b65b3ddcf01ab8704ac65616c5ce",
-                "sha256:7ec45a70d40ede1ec7ad7f95b3c94c9cf4c186a32f6bacb1795b60abd2f9ef27",
-                "sha256:86c857510a9b7c3104cf4cde1568f4921762c8f9842e987bc03ed4f160925754",
-                "sha256:8a627507ef9b307b46a1fea9513d5c98680ba09591253082b4c48697ba05a4ae",
-                "sha256:8dfb69fbf9f3aeed18afffb15e319ca7f8da9642336348ddd6cab2713ddcf8f9",
-                "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600",
-                "sha256:a8ffcd53cb5dfc131850851cc09f1c44689c2812d0beb954d8138d4f5fc17f65",
-                "sha256:b90928f2d9eb2f33162405f32dde9f6dcead63a0971ca8a1b50eb4ca3e35ceb8",
-                "sha256:c56ffe22faa2e51054c5f7a3bc70a370939c2ed4de308c690e7949230c995913",
-                "sha256:f91c7ae919bbc3f96cd5e5b2e786b2b108343d1d7972ea130f7de27fdd547cf3"
-            ],
-            "index": "pypi",
-            "version": "==0.770"
-        },
-        "mypy-extensions": {
-            "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
-            ],
-            "version": "==0.4.3"
         },
         "nodeenv": {
             "hashes": [
@@ -401,11 +365,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:487c675916e6f99d355ec5595ad77b325689d423ef4839db1ed2f02f639c9522",
-                "sha256:c0aa11bce04a7b46c5544723aedf4e81a4d5f64ad1205a30a9ea12d5e81969e1"
+                "sha256:22e6aa3bd571debb01eb7d34483f11c01b65237be4eebbf30c3d4fb65762d315",
+                "sha256:905ebc9b534b991baec87e934431f2d0606ba27f2b90f7f652985f5a5b8b6ae6"
             ],
             "index": "pypi",
-            "version": "==2.2.0"
+            "version": "==2.8.2"
         },
         "py": {
             "hashes": [
@@ -416,10 +380,10 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pycparser": {
             "hashes": [
@@ -430,10 +394,10 @@
         },
         "pyflakes": {
             "hashes": [
-                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
-                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "version": "==2.1.1"
+            "version": "==2.2.0"
         },
         "pygments": {
             "hashes": [
@@ -451,19 +415,19 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe",
+                "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==6.1.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
-                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+                "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191",
+                "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.10.1"
         },
         "pyyaml": {
             "hashes": [
@@ -502,6 +466,13 @@
             ],
             "version": "==0.9.1"
         },
+        "rfc3986": {
+            "hashes": [
+                "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d",
+                "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"
+            ],
+            "version": "==1.4.0"
+        },
         "secretstorage": {
             "hashes": [
                 "sha256:15da8a989b65498e29be338b3b279965f1b8f09b9668bd8010da183024c8bff6",
@@ -519,10 +490,10 @@
         },
         "toml": {
             "hashes": [
-                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
-                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "version": "==0.10.1"
+            "version": "==0.10.2"
         },
         "tqdm": {
             "hashes": [
@@ -533,51 +504,11 @@
         },
         "twine": {
             "hashes": [
-                "sha256:c1af8ca391e43b0a06bbc155f7f67db0bf0d19d284bfc88d1675da497a946124",
-                "sha256:d561a5e511f70275e5a485a6275ff61851c16ffcb3a95a602189161112d9f160"
+                "sha256:34352fd52ec3b9d29837e6072d5a2a7c6fe4290e97bba46bb8d478b5c598f7ab",
+                "sha256:ba9ff477b8d6de0c89dd450e70b2185da190514e91c42cc62f96850025c10472"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
-        },
-        "typed-ast": {
-            "hashes": [
-                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
-                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
-                "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d",
-                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
-                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
-                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
-                "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c",
-                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
-                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
-                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
-                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
-                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
-                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
-                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
-                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
-                "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c",
-                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
-                "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395",
-                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
-                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
-                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
-                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
-                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
-                "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072",
-                "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91",
-                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
-                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
-            ],
-            "version": "==1.4.1"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
-                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
-                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
-            ],
-            "version": "==3.7.4.3"
+            "version": "==3.2.0"
         },
         "urllib3": {
             "hashes": [
@@ -593,13 +524,6 @@
             ],
             "version": "==20.1.0"
         },
-        "wcwidth": {
-            "hashes": [
-                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
-                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
-            ],
-            "version": "==0.2.5"
-        },
         "webencodings": {
             "hashes": [
                 "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
@@ -609,18 +533,11 @@
         },
         "wheel": {
             "hashes": [
-                "sha256:8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96",
-                "sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e"
+                "sha256:497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2",
+                "sha256:99a22d87add3f634ff917310a3d87e499f19e663413a52eb9232c447aa646c9f"
             ],
             "index": "pypi",
-            "version": "==0.34.2"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
-                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
-            ],
-            "version": "==3.4.0"
+            "version": "==0.35.1"
         }
     }
 }

--- a/data_lineage/data_lineage.py
+++ b/data_lineage/data_lineage.py
@@ -1,6 +1,10 @@
 from data_lineage.graph.graph import Graph
 from data_lineage.parser.parser import parse as parse_single
-from data_lineage.visitors.dml_visitor import SelectSourceVisitor, SelectIntoVisitor, CopyFromVisitor
+from data_lineage.visitors.dml_visitor import (
+    CopyFromVisitor,
+    SelectIntoVisitor,
+    SelectSourceVisitor,
+)
 
 
 def parse(queries):

--- a/data_lineage/graph/graph.py
+++ b/data_lineage/graph/graph.py
@@ -75,7 +75,7 @@ class Graph:
         for current_phase in phases:
             y = 0
             for n in sorted(current_phase):
-                self._graph.nodes[n]['pos'] = [x, y]
+                self._graph.nodes[n]["pos"] = [x, y]
                 y += 1
             x += 1
 
@@ -86,8 +86,8 @@ class Graph:
         edge_x = []
         edge_y = []
         for edge in self._graph.edges():
-            x0, y0 = self._graph.nodes[edge[0]]['pos']
-            x1, y1 = self._graph.nodes[edge[1]]['pos']
+            x0, y0 = self._graph.nodes[edge[0]]["pos"]
+            x1, y1 = self._graph.nodes[edge[1]]["pos"]
             edge_x.append(x0)
             edge_x.append(x1)
             edge_x.append(None)
@@ -96,48 +96,61 @@ class Graph:
             edge_y.append(None)
 
         edge_trace = go.Scatter(
-            x=edge_x, y=edge_y,
-            line=dict(width=0.5, color='#888'),
-            hoverinfo='none',
-            mode='lines')
+            x=edge_x,
+            y=edge_y,
+            line=dict(width=0.5, color="#888"),
+            hoverinfo="none",
+            mode="lines",
+        )
 
         node_x = []
         node_y = []
         node_text = []
         for node in self._graph.nodes():
-            x, y = self._graph.nodes[node]['pos']
+            x, y = self._graph.nodes[node]["pos"]
             node_x.append(x)
             node_y.append(y)
             node_text.append(node)
 
         node_trace = go.Scatter(
-            x=node_x, y=node_y, text=node_text,
-            mode='markers',
-            hoverinfo='text',
+            x=node_x,
+            y=node_y,
+            text=node_text,
+            mode="markers",
+            hoverinfo="text",
             marker=dict(
                 showscale=False,
                 # colorscale options
                 # 'Greys' | 'YlGnBu' | 'Greens' | 'YlOrRd' | 'Bluered' | 'RdBu' |
                 # 'Reds' | 'Blues' | 'Picnic' | 'Rainbow' | 'Portland' | 'Jet' |
                 # 'Hot' | 'Blackbody' | 'Earth' | 'Electric' | 'Viridis' |
-                colorscale='YlGnBu',
+                colorscale="YlGnBu",
                 reversescale=True,
                 color=[],
                 size=10,
-                line_width=2))
+                line_width=2,
+            ),
+        )
 
-        return go.Figure(data=[edge_trace, node_trace],
-                         layout=go.Layout(
-                             title=self.name,
-                             titlefont_size=16,
-                             showlegend=False,
-                             hovermode='closest',
-                             margin=dict(b=20, l=5, r=5, t=40),
-                             annotations=[dict(
-                                 text="Generated using: <a href='https://tokern.io/data-lineage/'> Tokern Data Lineage</a>",
-                                 showarrow=False,
-                                 xref="paper", yref="paper",
-                                 x=0.005, y=-0.002)],
-                             xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
-                             yaxis=dict(showgrid=False, zeroline=False, showticklabels=False))
-                         )
+        return go.Figure(
+            data=[edge_trace, node_trace],
+            layout=go.Layout(
+                title=self.name,
+                titlefont_size=16,
+                showlegend=False,
+                hovermode="closest",
+                margin=dict(b=20, l=5, r=5, t=40),
+                annotations=[
+                    dict(
+                        text="Generated using: <a href='https://tokern.io/data-lineage/'> Tokern Data Lineage</a>",
+                        showarrow=False,
+                        xref="paper",
+                        yref="paper",
+                        x=0.005,
+                        y=-0.002,
+                    )
+                ],
+                xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+                yaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+            ),
+        )

--- a/data_lineage/parser/node.py
+++ b/data_lineage/parser/node.py
@@ -40,15 +40,19 @@ class AcceptingBase:
     a ``list`` produces a :class:`List` instance, everything else a :class:`Scalar` instance.
     """
 
-    __slots__ = ('_parent_node', '_parent_attribute')
+    __slots__ = ("_parent_node", "_parent_attribute")
 
     def __new__(cls, details, parent=None, name=None):
         if not isinstance(parent, (AcceptingNode, NoneType)):
-            raise ValueError("Unexpected value for 'parent', must be either None"
-                             " or a Node instance, got %r" % type(parent))
+            raise ValueError(
+                "Unexpected value for 'parent', must be either None"
+                " or a Node instance, got %r" % type(parent)
+            )
         if not isinstance(name, (NoneType, str, tuple)):
-            raise ValueError("Unexpected value for 'name', must be either None,"
-                             " a string or a tuple, got %r" % type(name))
+            raise ValueError(
+                "Unexpected value for 'name', must be either None,"
+                " a string or a tuple, got %r" % type(name)
+            )
         if isinstance(details, list):
             self = super().__new__(AcceptingList)
         elif isinstance(details, dict):
@@ -64,14 +68,16 @@ class AcceptingBase:
 
     def __eq__(self, other):
         if type(self) is type(other):
-            return all(getattr(self, slot) == getattr(other, slot) for slot in self.__slots__)
+            return all(
+                getattr(self, slot) == getattr(other, slot) for slot in self.__slots__
+            )
         return False
 
     def __str__(self):
         aname = self._parent_attribute
         if isinstance(aname, tuple):
-            aname = '%s[%d]' % aname
-        return '%s=%r' % (aname, self)
+            aname = "%s[%d]" % aname
+        return "%s=%r" % (aname, self)
 
     @property
     def parent_node(self):
@@ -103,12 +109,14 @@ class AcceptingList(AcceptingBase):
                  nodes
     """
 
-    __slots__ = AcceptingBase.__slots__ + ('_items',)
+    __slots__ = AcceptingBase.__slots__ + ("_items",)
 
     def _init(self, items, parent, name):
         if not isinstance(items, list) or not items:
-            raise ValueError("Unexpected value for 'items', must be a non empty"
-                             " list, got %r" % type(items))
+            raise ValueError(
+                "Unexpected value for 'items', must be a non empty"
+                " list, got %r" % type(items)
+            )
         super()._init(parent, name)
         self._items = items
 
@@ -121,7 +129,7 @@ class AcceptingList(AcceptingBase):
         # this is primarily an helper for investigating the internals of a tree.
         count = len(self)
         pivot = self[0]
-        return '[%d*%r]' % (count, pivot)
+        return "[%d*%r]" % (count, pivot)
 
     def __iter__(self):
         pnode = self.parent_node
@@ -130,15 +138,17 @@ class AcceptingList(AcceptingBase):
             yield AcceptingBase(item, pnode, (aname, idx))
 
     def __getitem__(self, index):
-        return AcceptingBase(self._items[index], self.parent_node, (self.parent_attribute, index))
+        return AcceptingBase(
+            self._items[index], self.parent_node, (self.parent_attribute, index)
+        )
 
     @property
     def string_value(self):
         if len(self) != 1:
-            raise TypeError('%r does not contain a single String node' % self)
+            raise TypeError("%r does not contain a single String node" % self)
         node = self[0]
-        if node.node_tag != 'String':
-            raise TypeError('%r does not contain a single String node' % self)
+        if node.node_tag != "String":
+            raise TypeError("%r does not contain a single String node" % self)
         return node.str.value
 
     def traverse(self):
@@ -163,17 +173,19 @@ class AcceptingNode(AcceptingBase):
                  nodes
     """
 
-    __slots__ = AcceptingBase.__slots__ + ('_node_tag', '_parse_tree')
+    __slots__ = AcceptingBase.__slots__ + ("_node_tag", "_parse_tree")
 
     def _init(self, details, parent=None, name=None):
         if not isinstance(details, dict) or len(details) != 1:
-            raise ValueError("Unexpected value for 'details', must be a dict with"
-                             " exactly one key, got %r" % type(details))
+            raise ValueError(
+                "Unexpected value for 'details', must be a dict with"
+                " exactly one key, got %r" % type(details)
+            )
         super()._init(parent, name)
         (self._node_tag, self._parse_tree), *_ = details.items()
 
     def __repr__(self):
-        return '{%s}' % self._node_tag
+        return "{%s}" % self._node_tag
 
     def __getattr__(self, attr):
         try:
@@ -190,8 +202,9 @@ class AcceptingNode(AcceptingBase):
         elif isinstance(attr, str):
             return getattr(self, attr)
         else:
-            raise ValueError('Wrong key type %r, must be str or tuple'
-                             % type(attr).__name__)
+            raise ValueError(
+                "Wrong key type %r, must be str or tuple" % type(attr).__name__
+            )
 
     def __iter__(self):
         value = self._parse_tree
@@ -219,8 +232,8 @@ class AcceptingNode(AcceptingBase):
 
     @property
     def string_value(self):
-        if self.node_tag != 'String':
-            raise TypeError('%r is not a String node' % self)
+        if self.node_tag != "String":
+            raise TypeError("%r is not a String node" % self)
         return self.str.value
 
     def traverse(self):
@@ -234,12 +247,14 @@ class AcceptingNode(AcceptingBase):
 class AcceptingScalar(AcceptingBase):
     "Represent a single scalar value."
 
-    __slots__ = AcceptingBase.__slots__ + ('_value',)
+    __slots__ = AcceptingBase.__slots__ + ("_value",)
 
     def _init(self, value, parent, name):
         if not isinstance(value, (NoneType, bool, float, int, str)):
-            raise ValueError("Unexpected value for 'value', must be either None or a"
-                             " bool|float|int|str instance, got %r" % type(value))
+            raise ValueError(
+                "Unexpected value for 'value', must be either None or a"
+                " bool|float|int|str instance, got %r" % type(value)
+            )
         super()._init(parent, name)
         self._value = value
 
@@ -247,8 +262,9 @@ class AcceptingScalar(AcceptingBase):
         if isinstance(self._value, int) and isinstance(other, int):
             return self._value & other
         else:
-            raise ValueError("Wrong operands for __and__: %r & %r"
-                             % (type(self._value), type(other)))
+            raise ValueError(
+                "Wrong operands for __and__: %r & %r" % (type(self._value), type(other))
+            )
 
     def __bool__(self):
         if self.value is None:
@@ -273,7 +289,7 @@ class AcceptingScalar(AcceptingBase):
             return super().__eq__(other)
 
     def __repr__(self):
-        return '<%r>' % self._value
+        return "<%r>" % self._value
 
     def traverse(self):
         yield self

--- a/data_lineage/parser/visitor.py
+++ b/data_lineage/parser/visitor.py
@@ -1,7 +1,13 @@
-import inflection
 import logging
 
-from data_lineage.parser.node import AcceptingBase, AcceptingList, AcceptingNode, AcceptingScalar, Missing
+import inflection
+
+from data_lineage.parser.node import (
+    AcceptingList,
+    AcceptingNode,
+    AcceptingScalar,
+    Missing,
+)
 
 
 class Visitor:

--- a/data_lineage/visitors/dml_visitor.py
+++ b/data_lineage/visitors/dml_visitor.py
@@ -1,5 +1,3 @@
-import logging
-
 from data_lineage.parser.visitor import Visitor
 from data_lineage.visitors.table_visitor import TableVisitor
 
@@ -43,6 +41,3 @@ class CopyFromVisitor(DmlVisitor):
     def visit_copy_stmt(self, node):
         if node.is_from:
             super(CopyFromVisitor, self).visit_copy_stmt(node)
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--i https://pypi.python.org/simple/
 decorator==4.4.2
 inflection==0.3.1
 networkx==2.4

--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,24 @@ import re
 import sys
 from os import getenv, path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-_version_re = re.compile(r'__version__\s*=\s*(.*)')
+_version_re = re.compile(r"__version__\s*=\s*(.*)")
 
-with open('data_lineage/__init__.py', 'rb') as f:
-    __version__ = str(ast.literal_eval(_version_re.search(
-        f.read().decode('utf-8')).group(1)))
+with open("data_lineage/__init__.py", "rb") as f:
+    __version__ = str(
+        ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
+    )
 
 
 class VerifyVersionCommand(install):
     """Custom command to verify that the git tag matches our version"""
-    description = 'verify that the git tag matches our version'
+
+    description = "verify that the git tag matches our version"
 
     def run(self):
-        tag = getenv('CIRCLE_TAG')
+        tag = getenv("CIRCLE_TAG")
 
         if tag != ("v%s" % __version__):
             info = "Git tag: {0} does not match the version of this app: {1}".format(
@@ -30,43 +32,43 @@ class VerifyVersionCommand(install):
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 # get the dependencies and installs
-with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
+with open(path.join(here, "requirements.txt"), encoding="utf-8") as f:
+    all_reqs = f.read().split("\n")
 
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
-dependency_links = [x.strip().replace('git+', '') for x in all_reqs if x.startswith('git+')]
+install_requires = [x.strip() for x in all_reqs if "git+" not in x]
+dependency_links = [
+    x.strip().replace("git+", "") for x in all_reqs if x.startswith("git+")
+]
 
 setup(
-    name='data-lineage',
+    name="data-lineage",
     version=__version__,
-    packages=find_packages(exclude=['docs', 'test*']),
-    url='https://tokern.io/lineage',
-    license='MIT',
-    author='Tokern',
-    author_email='info@tokern.io',
-    description='Open Source Data Lineage Tool For AWS and GCP',
+    packages=find_packages(exclude=["docs", "test*"]),
+    url="https://tokern.io/lineage",
+    license="MIT",
+    author="Tokern",
+    author_email="info@tokern.io",
+    description="Open Source Data Lineage Tool For AWS and GCP",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    download_url='https://github.com/tokern/data-lineage/tarball/' + __version__,
+    download_url="https://github.com/tokern/data-lineage/tarball/" + __version__,
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Database',
-        'Topic :: Software Development',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Database",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    keywords='data-lineage databases postgres graphs plotly',
+    keywords="data-lineage databases postgres graphs plotly",
     install_requires=install_requires,
     dependency_links=dependency_links,
-    cmdclass={
-        'verify': VerifyVersionCommand,
-    }
+    cmdclass={"verify": VerifyVersionCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -35,15 +35,6 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-# get the dependencies and installs
-with open(path.join(here, "requirements.txt"), encoding="utf-8") as f:
-    all_reqs = f.read().split("\n")
-
-install_requires = [x.strip() for x in all_reqs if "git+" not in x]
-dependency_links = [
-    x.strip().replace("git+", "") for x in all_reqs if x.startswith("git+")
-]
-
 setup(
     name="data-lineage",
     version=__version__,
@@ -68,7 +59,15 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     keywords="data-lineage databases postgres graphs plotly",
-    install_requires=install_requires,
-    dependency_links=dependency_links,
+    install_requires=[
+        "decorator==4.4.2",
+        "inflection==0.5.1",
+        "networkx==2.5",
+        "pglast==1.14",
+        "plotly==4.12.0",
+        "retrying==1.3.3",
+        "six==1.15.0",
+    ],
+    dependency_links=[],
     cmdclass={"verify": VerifyVersionCommand},
 )

--- a/test/test_data_lineage.py
+++ b/test/test_data_lineage.py
@@ -1,21 +1,21 @@
-from networkx import nodes, edges
+from networkx import edges, nodes
 
 from data_lineage.catalog.query import Query
-from data_lineage.data_lineage import parse, get_dml_queries, create_graph
+from data_lineage.data_lineage import create_graph, get_dml_queries, parse
 
 queries = [
     """
-    INSERT INTO page_lookup_nonredirect 
-            SELECT  page.page_id as redircet_id, page.page_title as redirect_title, page.page_title true_title, 
-                    page.page_id, page.page_latest 
+    INSERT INTO page_lookup_nonredirect
+            SELECT  page.page_id as redircet_id, page.page_title as redirect_title, page.page_title true_title,
+                    page.page_id, page.page_latest
             FROM page LEFT OUTER JOIN redirect ON page.page_id = redirect.rd_from
             WHERE redirect.rd_from IS NULL
     """,
     """
-    insert into page_lookup_redirect 
-            select original_page.page_id redirect_id, original_page.page_title redirect_title, 
-                    final_page.page_title as true_title, final_page.page_id, final_page.page_latest 
-            from page final_page join redirect on (redirect.page_title = final_page.page_title) 
+    insert into page_lookup_redirect
+            select original_page.page_id redirect_id, original_page.page_title redirect_title,
+                    final_page.page_title as true_title, final_page.page_id, final_page.page_latest
+            from page final_page join redirect on (redirect.page_title = final_page.page_title)
                 join page original_page on (redirect.rd_from = original_page.page_id)
     """,
     """
@@ -29,28 +29,28 @@ queries = [
                 FROM page_lookup_redirect) u
     """,
     """
-           INSERT INTO filtered_pagecounts 
-           SELECT regexp_replace (reflect ('java.net.URLDecoder','decode', reflect ('java.net.URLDecoder','decode',pvs.page_title)),'^\s*([a-zA-Z0-9]+).*','$1') page_title 
+           INSERT INTO filtered_pagecounts
+           SELECT regexp_replace (reflect ('java.net.URLDecoder','decode', reflect ('java.net.URLDecoder','decode',pvs.page_title)),'^\\s*([a-zA-Z0-9]+).*','$1') page_title
                 ,SUM (pvs.views) AS total_views, SUM (pvs.bytes_sent) AS total_bytes_sent
-            FROM pagecounts as pvs 
-           WHERE not pvs.page_title LIKE '(MEDIA|SPECIAL||Talk|User|User_talk|Project|Project_talk|File|File_talk|MediaWiki|MediaWiki_talk|Template|Template_talk|Help|Help_talk|Category|Category_talk|Portal|Wikipedia|Wikipedia_talk|upload|Special)\:(.*)' and
+            FROM pagecounts as pvs
+           WHERE not pvs.page_title LIKE '(MEDIA|SPECIAL||Talk|User|User_talk|Project|Project_talk|File|File_talk|MediaWiki|MediaWiki_talk|Template|Template_talk|Help|Help_talk|Category|Category_talk|Portal|Wikipedia|Wikipedia_talk|upload|Special)\\:(.*)' and
                 pvs.page_title LIKE '^([A-Z])(.*)' and
                 not pvs.page_title LIKE '(.*).(jpg|gif|png|JPG|GIF|PNG|txt|ico)$' and
-                pvs.page_title <> '404_error/' and 
-                pvs.page_title <> 'Main_Page' and 
-                pvs.page_title <> 'Hypertext_Transfer_Protocol' and 
-                pvs.page_title <> 'Favicon.ico' and 
-                pvs.page_title <> 'Search' and 
+                pvs.page_title <> '404_error/' and
+                pvs.page_title <> 'Main_Page' and
+                pvs.page_title <> 'Hypertext_Transfer_Protocol' and
+                pvs.page_title <> 'Favicon.ico' and
+                pvs.page_title <> 'Search' and
                 pvs.dt = '2020-01-01'
-          GROUP BY 
-                regexp_replace (reflect ('java.net.URLDecoder','decode', reflect ('java.net.URLDecoder','decode',pvs.page_title)),'^\s*([a-zA-Z0-9]+).*','$1')
+          GROUP BY
+                regexp_replace (reflect ('java.net.URLDecoder','decode', reflect ('java.net.URLDecoder','decode',pvs.page_title)),'^\\s*([a-zA-Z0-9]+).*','$1')
     """,
     """
     INSERT INTO normalized_pagecounts
            SELECT pl.page_id page_id, REGEXP_REPLACE(pl.true_title, '_', ' ') page_title, pl.true_title page_url, views, bytes_sent
-           FROM page_lookup pl JOIN filtered_pagecounts fp 
+           FROM page_lookup pl JOIN filtered_pagecounts fp
            ON fp.page_title = pl.redirect_title where fp.dt='2020-01-01'
-    """
+    """,
 ]
 
 
@@ -80,26 +80,26 @@ def test_graph():
     graph = create_graph(dml)
 
     assert list(nodes(graph.graph)) == [
-        (None, 'page_lookup_nonredirect'),
-        (None, 'page'),
-        (None, 'redirect'),
-        (None, 'page_lookup_redirect'),
-        (None, 'page_lookup'),
-        (None, 'filtered_pagecounts'),
-        (None, 'pagecounts'),
-        (None, 'normalized_pagecounts')
+        (None, "page_lookup_nonredirect"),
+        (None, "page"),
+        (None, "redirect"),
+        (None, "page_lookup_redirect"),
+        (None, "page_lookup"),
+        (None, "filtered_pagecounts"),
+        (None, "pagecounts"),
+        (None, "normalized_pagecounts"),
     ]
 
     assert list(edges(graph.graph)) == [
-        ((None, 'page_lookup_nonredirect'), (None, 'page_lookup')),
-        ((None, 'page'), (None, 'page_lookup_nonredirect')),
-        ((None, 'page'), (None, 'page_lookup_redirect')),
-        ((None, 'redirect'), (None, 'page_lookup_nonredirect')),
-        ((None, 'redirect'), (None, 'page_lookup_redirect')),
-        ((None, 'page_lookup_redirect'), (None, 'page_lookup')),
-        ((None, 'page_lookup'), (None, 'normalized_pagecounts')),
-        ((None, 'filtered_pagecounts'), (None, 'normalized_pagecounts')),
-        ((None, 'pagecounts'), (None, 'filtered_pagecounts'))
+        ((None, "page_lookup_nonredirect"), (None, "page_lookup")),
+        ((None, "page"), (None, "page_lookup_nonredirect")),
+        ((None, "page"), (None, "page_lookup_redirect")),
+        ((None, "redirect"), (None, "page_lookup_nonredirect")),
+        ((None, "redirect"), (None, "page_lookup_redirect")),
+        ((None, "page_lookup_redirect"), (None, "page_lookup")),
+        ((None, "page_lookup"), (None, "normalized_pagecounts")),
+        ((None, "filtered_pagecounts"), (None, "normalized_pagecounts")),
+        ((None, "pagecounts"), (None, "filtered_pagecounts")),
     ]
 
 
@@ -108,23 +108,26 @@ def test_phases():
     phases = graph._phases()
 
     assert phases == [
-        [(None, 'page'), (None, 'redirect'), (None, 'pagecounts')],
-        [(None, 'page_lookup_nonredirect'), (None, 'page_lookup_redirect'), (None, 'filtered_pagecounts')],
-        [(None, 'page_lookup')],
-        [(None, 'normalized_pagecounts')]
+        [(None, "page"), (None, "redirect"), (None, "pagecounts")],
+        [
+            (None, "page_lookup_nonredirect"),
+            (None, "page_lookup_redirect"),
+            (None, "filtered_pagecounts"),
+        ],
+        [(None, "page_lookup")],
+        [(None, "normalized_pagecounts")],
     ]
 
 
-def test_phases():
+def test_node_positions():
     graph = create_graph(get_dml_queries(parse([Query(q) for q in queries])))
     graph._set_node_positions(graph._phases())
 
-    assert graph.graph.nodes[(None, 'page')]['pos'] == [0, 0]
-    assert graph.graph.nodes[(None, 'pagecounts')]['pos'] == [0, 1]
-    assert graph.graph.nodes[(None, 'redirect')]['pos'] == [0, 2]
-    assert graph.graph.nodes[(None, 'filtered_pagecounts')]['pos'] == [1, 0]
-    assert graph.graph.nodes[(None, 'page_lookup_nonredirect')]['pos'] == [1, 1]
-    assert graph.graph.nodes[(None, 'page_lookup_redirect')]['pos'] == [1, 2]
-    assert graph.graph.nodes[(None, 'page_lookup')]['pos'] == [2, 0]
-    assert graph.graph.nodes[(None, 'normalized_pagecounts')]['pos'] == [3, 0]
-
+    assert graph.graph.nodes[(None, "page")]["pos"] == [0, 0]
+    assert graph.graph.nodes[(None, "pagecounts")]["pos"] == [0, 1]
+    assert graph.graph.nodes[(None, "redirect")]["pos"] == [0, 2]
+    assert graph.graph.nodes[(None, "filtered_pagecounts")]["pos"] == [1, 0]
+    assert graph.graph.nodes[(None, "page_lookup_nonredirect")]["pos"] == [1, 1]
+    assert graph.graph.nodes[(None, "page_lookup_redirect")]["pos"] == [1, 2]
+    assert graph.graph.nodes[(None, "page_lookup")]["pos"] == [2, 0]
+    assert graph.graph.nodes[(None, "normalized_pagecounts")]["pos"] == [3, 0]

--- a/test/test_dml_visitor.py
+++ b/test/test_dml_visitor.py
@@ -1,16 +1,35 @@
 import pytest
 
 from data_lineage.parser.parser import parse
-from data_lineage.visitors.dml_visitor import SelectSourceVisitor, SelectIntoVisitor, CopyFromVisitor
+from data_lineage.visitors.dml_visitor import (
+    CopyFromVisitor,
+    SelectIntoVisitor,
+    SelectSourceVisitor,
+)
 
 
-@pytest.mark.parametrize("target, sources, sql", [
-    ((None, "c"), [(None, "a")], "insert into c select * from a"),
-    ((None, "c"), [(None, "a"), (None, "b")], "insert into c select * from a join b on a.id = b.id"),
-    ((None, "c"), [(None, "a"), (None, "b")], "insert into c select * from (select * from a join b on a.id = b.id) x"),
-    ((None, "c"), [(None, "a"), (None, "b")], "insert into c select * from (select * from a as aa join b on "
-                                              "aa.id = b.id) x")
-])
+@pytest.mark.parametrize(
+    "target, sources, sql",
+    [
+        ((None, "c"), [(None, "a")], "insert into c select * from a"),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "insert into c select * from a join b on a.id = b.id",
+        ),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "insert into c select * from (select * from a join b on a.id = b.id) x",
+        ),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "insert into c select * from (select * from a as aa join b on "
+            "aa.id = b.id) x",
+        ),
+    ],
+)
 def test_sanity_insert(target, sources, sql):
     node = parse(sql)
     insert_visitor = SelectSourceVisitor()
@@ -20,14 +39,29 @@ def test_sanity_insert(target, sources, sql):
     assert insert_visitor.sources == sources
 
 
-@pytest.mark.parametrize("target, sources, sql", [
-    ((None, "c"), [(None, "a")], "create table c as select * from a"),
-    ((None, "c"), [(None, "a"), (None, "b")], "create table c as select * from a join b on a.id = b.id"),
-    ((None, "c"), [(None, "a"), (None, "b")], "create table c as select * from (select * from a join b on a.id = b.id)"
-                                              " x"),
-    ((None, "c"), [(None, "a"), (None, "b")], "create table c as select * from (select * from a as aa join b on "
-                                              "aa.id = b.id) x")
-])
+@pytest.mark.parametrize(
+    "target, sources, sql",
+    [
+        ((None, "c"), [(None, "a")], "create table c as select * from a"),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "create table c as select * from a join b on a.id = b.id",
+        ),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "create table c as select * from (select * from a join b on a.id = b.id)"
+            " x",
+        ),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "create table c as select * from (select * from a as aa join b on "
+            "aa.id = b.id) x",
+        ),
+    ],
+)
 def test_sanity_ctas(target, sources, sql):
     node = parse(sql)
     visitor = SelectSourceVisitor()
@@ -37,11 +71,26 @@ def test_sanity_ctas(target, sources, sql):
     assert visitor.sources == sources
 
 
-@pytest.mark.parametrize("target, sources, sql", [
-    ((None, "c"), [(None, "a"), (None, "b")], "select * into c from a join b on a.id = b.id"),
-    ((None, "c"), [(None, "a"), (None, "b")], "select * into c from (select * from a join b on a.id = b.id) x"),
-    ((None, "c"), [(None, "a"), (None, "b")], "select * into c from (select * from a as aa join b on aa.id = b.id) x")
-])
+@pytest.mark.parametrize(
+    "target, sources, sql",
+    [
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "select * into c from a join b on a.id = b.id",
+        ),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "select * into c from (select * from a join b on a.id = b.id) x",
+        ),
+        (
+            (None, "c"),
+            [(None, "a"), (None, "b")],
+            "select * into c from (select * from a as aa join b on aa.id = b.id) x",
+        ),
+    ],
+)
 def test_sanity_select_into(target, sources, sql):
     node = parse(sql)
     visitor = SelectIntoVisitor()
@@ -51,13 +100,16 @@ def test_sanity_select_into(target, sources, sql):
     assert visitor.sources == sources
 
 
-@pytest.mark.parametrize("target, query", [
-    ((None, "a"), "copy a from stdin"),
-    # (("a", "b"), "copy a.b from 's3://bucket/dir' CREDENTIALS '' JSON AS 's3://bucket/schema.json' REGION AS 'region'"
-    #             " MAXERROR 1 TRUNCATECOLUMNS TIMEFORMAT 'auto' ACCEPTINVCHARS"),
-    # (("a", "b"), "copy a.b(c, d, e) from 's3://bucket/dir' CREDENTIALS '' delimiter ',' REMOVEQUOTES ACCEPTINVCHARS "
-    #             "IGNOREHEADER 1")
-])
+@pytest.mark.parametrize(
+    "target, query",
+    [
+        ((None, "a"), "copy a from stdin"),
+        # (("a", "b"), "copy a.b from 's3://bucket/dir' CREDENTIALS '' JSON AS 's3://bucket/schema.json' REGION AS 'region'"
+        #             " MAXERROR 1 TRUNCATECOLUMNS TIMEFORMAT 'auto' ACCEPTINVCHARS"),
+        # (("a", "b"), "copy a.b(c, d, e) from 's3://bucket/dir' CREDENTIALS '' delimiter ',' REMOVEQUOTES ACCEPTINVCHARS "
+        #             "IGNOREHEADER 1")
+    ],
+)
 def test_copy(target, query):
     node = parse(query)
     visitor = CopyFromVisitor()


### PR DESCRIPTION
The following tests have been enabled:
- black
- flake
- isort
- pytest & coverage

These tests are also run as part of circleci scripts.
Also the source code has been modified to pass these tests.