### PR TITLE
fix: Fix documentation and examples for latest version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ example of how data lineage can be used in production.
 
 ## Quick Start
 
-Install a demo of using Docker and Docker Compose
+### Install a demo of using Docker and Docker Compose
 
 Download the docker-compose file from Github repository.
 
 
     # in a new directory run
-    wget https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose-demodb/docker-compose.yml
+    wget https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/catalog-demo.yml
     # or run
-    curl https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose-demodb/docker-compose.yml -o docker-compose.yml
+    curl https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/catalog-demo.yml -o docker-compose.yml
 
 
 Run docker-compose
@@ -57,6 +57,25 @@ Try out Tokern Lineage App
 
 Head to `http://localhost:8000/` to open the Tokern Lineage app
 
+### Install Tokern Lineage Engine
+
+    # in a new directory run
+    wget https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/tokern-lineage-engine.yml
+    # or run
+    curl https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/catalog-demo.yml -o tokern-lineage-engine.yml
+
+Run docker-compose
+   
+
+    docker-compose up -d
+
+
+If you want to use an external Postgres database, replace the following parameters in `tokern-lineage-engine.yml`:
+
+* CATALOG_HOST
+* CATALOG_USER
+* CATALOG_PASSWORD
+* CATALOG_DB
 
 ## Supported Technologies
 
@@ -66,7 +85,6 @@ Head to `http://localhost:8000/` to open the Tokern Lineage app
 
 ### Coming Soon
 
-* MySQL
 * SparkSQL
 * Presto
 

--- a/api_example.ipynb
+++ b/api_example.ipynb
@@ -22,8 +22,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6a9c9b70",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Installation\n",
+    "\n",
+    "This demo requires wikimedia demo to be running. Start the demo using the following instructions:\n",
+    "\n",
+    "    # in a new directory run\n",
+    "    wget https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/wikimedia-demo.yml\n",
+    "    # or run\n",
+    "    curl https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/wikimedia-demo.yml -o docker-compose.yml\n",
+    "\n",
+    "\n",
+    "Run docker-compose\n",
+    "\n",
+    "\n",
+    "    docker-compose up -d\n",
+    "\n",
+    "\n",
+    "Verify container are running\n",
+    "\n",
+    "\n",
+    "    docker container ls | grep tokern\n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "37651618",
    "metadata": {},
    "outputs": [],
@@ -42,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "wrong-antigua",
    "metadata": {
     "scrolled": true
@@ -57,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "23ed8c16",
    "metadata": {
     "pycharm": {
@@ -74,12 +105,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "ce6ebf16",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Scan the wikimedia data warehouse and register all schemata, tables and columns.\n",
     "\n",
@@ -88,12 +130,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "202c6b63",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'attributes': {'context': {'sql': 'insert into page_lookup_nonredirect(redirect_id) select page_id from page'}, 'name': 'insert_into_page_lookup_nonredirect'}, 'id': '1', 'links': {'self': 'http://tokern-api:4142/api/v1/catalog/jobs/1'}, 'type': 'jobs'}\n"
+     ]
+    }
+   ],
    "source": [
     "# Create a job and job_execution that inserts data from page to page_lookup_nonredirect\n",
     "\n",
@@ -105,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "cf308d97",
    "metadata": {
     "scrolled": true
@@ -129,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b45aaac8",
    "metadata": {},
    "outputs": [],
@@ -140,7 +190,7 @@
     "source_column = catalog.get_column(source_name=\"wikimedia\", \n",
     "                                   schema_name=\"public\", \n",
     "                                   table_name=\"page\",\n",
-    "                                   column_name=\"pageid\")\n",
+    "                                   column_name=\"page_id\")\n",
     "target_column = catalog.get_column(source_name=\"wikimedia\", \n",
     "                                   schema_name=\"public\", \n",
     "                                   table_name=\"page_lookup_nonredirect\",\n",

--- a/example.ipynb
+++ b/example.ipynb
@@ -17,6 +17,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Installation\n",
+    "\n",
+    "This demo requires wikimedia demo to be running. Start the demo using the following instructions:\n",
+    "\n",
+    "    # in a new directory run\n",
+    "    wget https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/wikimedia-demo.yml\n",
+    "    # or run\n",
+    "    curl https://raw.githubusercontent.com/tokern/data-lineage/master/install-manifests/docker-compose/wikimedia-demo.yml -o docker-compose.yml\n",
+    "\n",
+    "\n",
+    "Run docker-compose\n",
+    "\n",
+    "\n",
+    "    docker-compose up -d\n",
+    "\n",
+    "\n",
+    "Verify container are running\n",
+    "\n",
+    "\n",
+    "    docker container ls | grep tokern\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -80,7 +106,7 @@
     "\n",
     "for query in queries:\n",
     "    print(query)\n",
-    "    parser.parse(**query)"
+    "    parser.parse(**query, source=source)"
    ]
   },
   {

--- a/install-manifests/docker-compose/catalog-demo.yml
+++ b/install-manifests/docker-compose/catalog-demo.yml
@@ -1,13 +1,13 @@
 version: '3.6'
 services:
-  tokern-catalog:
-    image: postgres:13.2-alpine
-    container_name: tokern-catalog
+  tokern-demo-catalog:
+    image: tokern/demo-catalog:latest
+    container_name: tokern-demo-catalog
     restart: unless-stopped
     networks:
       - tokern-internal
     volumes:
-    - tokern_catalog_data:/var/lib/postgresql/data
+    - tokern_demo_catalog_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: catal0g_passw0rd
       POSTGRES_USER: catalog_user
@@ -22,7 +22,7 @@ services:
       CATALOG_PASSWORD: catal0g_passw0rd
       CATALOG_USER: catalog_user
       CATALOG_DB: tokern
-      CATALOG_HOST: tokern-catalog
+      CATALOG_HOST: tokern-demo-catalog
       SERVER_ADDRESS: "0.0.0.0:4142"
   toker-viz:
     image: tokern/data-lineage-viz:latest
@@ -52,4 +52,4 @@ networks:
       - subnet: 10.11.0.0/24
 
 volumes:
-  tokern_catalog_data:
+  tokern_demo_catalog_data:

--- a/install-manifests/docker-compose/tokern-lineage-engine.yml
+++ b/install-manifests/docker-compose/tokern-lineage-engine.yml
@@ -12,24 +12,13 @@ services:
       POSTGRES_PASSWORD: catal0g_passw0rd
       POSTGRES_USER: catalog_user
       POSTGRES_DB: tokern
-  tokern-wikimedia:
-    image: tokern/demo-wikimedia:latest
-    container_name: tokern-demo-wikimedia
-    restart: unless-stopped
-    networks:
-      - tokern-internal
-    volumes:
-    - tokern_wikimedia_data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD: 3tld3v
-      POSTGRES_USER: etldev
-      POSTGRES_DB: wikimedia
   tokern-api:
     image: tokern/data-lineage:latest
     container_name: tokern-data-lineage
     restart: unless-stopped
     networks:
       - tokern-internal
+      - tokern-net
     environment:
       CATALOG_PASSWORD: catal0g_passw0rd
       CATALOG_USER: catalog_user
@@ -65,4 +54,3 @@ networks:
 
 volumes:
   tokern_catalog_data:
-  tokern_wikimedia_data:

--- a/install-manifests/docker-compose/wikimedia-demo.yml
+++ b/install-manifests/docker-compose/wikimedia-demo.yml
@@ -1,17 +1,29 @@
 version: '3.6'
 services:
-  tokern-demo-catalog:
-    image: tokern/demo-catalog:latest
-    container_name: tokern-demo-catalog
+  tokern-catalog:
+    image: postgres:13.2-alpine
+    container_name: tokern-catalog
     restart: unless-stopped
     networks:
       - tokern-internal
     volumes:
-    - db_data:/var/lib/postgresql/data
+    - tokern_wikimedia_catalog_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: catal0g_passw0rd
       POSTGRES_USER: catalog_user
       POSTGRES_DB: tokern
+  tokern-wikimedia:
+    image: tokern/demo-wikimedia:latest
+    container_name: tokern-demo-wikimedia
+    restart: unless-stopped
+    networks:
+      - tokern-internal
+    volumes:
+    - tokern_wikimedia_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: 3tld3v
+      POSTGRES_USER: etldev
+      POSTGRES_DB: wikimedia
   tokern-api:
     image: tokern/data-lineage:latest
     container_name: tokern-data-lineage
@@ -22,7 +34,7 @@ services:
       CATALOG_PASSWORD: catal0g_passw0rd
       CATALOG_USER: catalog_user
       CATALOG_DB: tokern
-      CATALOG_HOST: tokern-demo-catalog
+      CATALOG_HOST: tokern-catalog
       SERVER_ADDRESS: "0.0.0.0:4142"
   toker-viz:
     image: tokern/data-lineage-viz:latest
@@ -52,4 +64,5 @@ networks:
       - subnet: 10.11.0.0/24
 
 volumes:
-  db_data:
+  tokern_wikimedia_catalog_data:
+  tokern_wikimedia_data:

--- a/install-manifests/dockerfiles/demo-wikimedia.sql
+++ b/install-manifests/dockerfiles/demo-wikimedia.sql
@@ -54,8 +54,9 @@ ALTER TABLE public.page_lookup OWNER TO etldev;
 --
 
 CREATE TABLE public.normalized_pagecounts (
-    "group" character varying,
+    page_id bigint,
     page_title character varying,
+    page_url character varying,
     views bigint,
     bytes_sent bigint
 );


### PR DESCRIPTION
Examples provide instructions to install the right docker containers.
Fix outdated APIs in the example.
Reorganize files in install-manifests.

Fix #51