### PR TITLE
fix: tokern-lineage-engine should accept environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,26 @@ Run docker-compose
     docker-compose up -d
 
 
-If you want to use an external Postgres database, replace the following parameters in `tokern-lineage-engine.yml`:
+If you want to use an external Postgres database, change the following parameters in `tokern-lineage-engine.yml`:
 
 * CATALOG_HOST
 * CATALOG_USER
 * CATALOG_PASSWORD
 * CATALOG_DB
+
+You can also override default values using environement variables. 
+
+    CATALOG_HOST=... CATALOG_USER=... CATALOG_PASSWORD=... CATALOG_DB=... docker-compose -f ... up -d
+
+For more advanced usage of environment variables with docker-compose, [refer to docker-compose docs](https://docs.docker.com/compose/environment-variables/)
+
+**Pro-tip**
+
+If you want to connect to a database in the host machine, set 
+
+    CATALOG_HOST: host.docker.internal # For mac or windows
+    #OR
+    CATALOG_HOST: 172.17.0.1 # Linux
 
 ## Supported Technologies
 

--- a/data_lineage/__init__.py
+++ b/data_lineage/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = "0.7.6"
+__version__ = "0.7.7"
 
 import datetime
 import json

--- a/data_lineage/__main__.py
+++ b/data_lineage/__main__.py
@@ -25,7 +25,7 @@ from data_lineage.server import create_server
     "--catalog-port", help="Database Password", envvar="CATALOG_PORT", default=5432
 )
 @click.option(
-    "--catalog-db", help="Postgres Database", envvar="CATALOG_PORT", default="tokern"
+    "--catalog-db", help="Postgres Database", envvar="CATALOG_DB", default="tokern"
 )
 @click.option(
     "--server-address",

--- a/install-manifests/docker-compose/tokern-lineage-engine.yml
+++ b/install-manifests/docker-compose/tokern-lineage-engine.yml
@@ -20,12 +20,12 @@ services:
       - tokern-internal
       - tokern-net
     environment:
-      CATALOG_PASSWORD: catal0g_passw0rd
-      CATALOG_USER: catalog_user
-      CATALOG_DB: tokern
-      CATALOG_HOST: tokern-catalog
+      CATALOG_PASSWORD: ${CATALOG_PASSWORD:-catal0g_passw0rd}
+      CATALOG_USER: ${CATALOG_USER:-catalog_user}
+      CATALOG_DB: ${CATALOG_DB:-tokern}
+      CATALOG_HOST: ${CATALOG_HOST:-tokern-catalog}
       SERVER_ADDRESS: "0.0.0.0:4142"
-  toker-viz:
+  tokern-viz:
     image: tokern/data-lineage-viz:latest
     container_name: tokern-data-lineage-visualizer
     restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-lineage"
-version = "0.7.6"
+version = "0.7.7"
 description = "Open Source Data Lineage Tool for Redshift. Snowflake and many other databases"
 authors = ["Tokern <info@tokern.io>"]
 license = "MIT"


### PR DESCRIPTION
The file was ignoring environment variables passed through
docker-compose command.

Also the command-line wrongly accepted CATALOG_PORT for --catalog-db
option.

Update README to provide more information on connecting to an external
postgres.

Update version to 0.7.7

Fix #61