### PR TITLE
fix: Connection lost errors on macos

### DIFF
--- a/.idea/data-lineage.iml
+++ b/.idea/data-lineage.iml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
-    </content>
-    <orderEntry type="jdk" jdkName="Poetry (data-lineage) (2)" jdkType="Python SDK" />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PackageRequirementsSettings">
     <option name="requirementsPath" value="" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
   </component>
   <component name="TestRunnerService">
     <option name="PROJECT_TEST_RUNNER" value="pytest" />

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,5 @@
 <component name="InspectionProjectProfileManager">
   <settings>
-    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/data_lineage/server.py
+++ b/data_lineage/server.py
@@ -285,11 +285,14 @@ def create_server(
         **catalog_options,
         connect_args={"application_name": "data-lineage:flask-restless"},
         max_overflow=40,
-        pool_size=20
+        pool_size=20,
+        pool_pre_ping=True
     )
 
     restful_catalog = Catalog(
-        **catalog_options, connect_args={"application_name": "data-lineage:restful"}
+        **catalog_options,
+        connect_args={"application_name": "data-lineage:restful"},
+        pool_pre_ping=True
     )
 
     app = Flask(__name__)


### PR DESCRIPTION
Postgres connections are dropped when database is running in the host machine. 
This solution adds a parameter to SQLAlchemy to ping the database and reconnect if it is dropped.
This is pessimistic and may add latency. However it is the easiest solution.

Refer:
* https://stackoverflow.com/questions/55457069/how-to-fix-operationalerror-psycopg2-operationalerror-server-closed-the-conn
* https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic